### PR TITLE
Fixed #79 bug in vx_spawn.c for rT kernel iteration allocation

### DIFF
--- a/runtime/src/vx_spawn.c
+++ b/runtime/src/vx_spawn.c
@@ -189,10 +189,11 @@ static void __attribute__ ((noinline)) spawn_kernel_all_stub() {
 static void __attribute__ ((noinline)) spawn_kernel_rem_stub() {
   int core_id = vx_core_id(); 
   int tid = vx_thread_gid();
+  int NT  = vx_num_threads();
 
   wspawn_kernel_args_t* p_wspawn_args = (wspawn_kernel_args_t*)g_wspawn_args[core_id];
 
-  int wg_id = p_wspawn_args->offset + tid;
+  int wg_id = p_wspawn_args->offset + tid%NT + core_id*NT;
 
   int X = p_wspawn_args->ctx->num_groups[0];
   int Y = p_wspawn_args->ctx->num_groups[1];
@@ -296,7 +297,7 @@ void vx_spawn_kernel(context_t * ctx, vx_spawn_kernel_cb callback, void * arg) {
 
   //--    
   if (rT != 0) {
-    wspawn_args.offset = wgs_per_core0 - rT;
+    wspawn_args.offset = wgs_per_core*core_id + nW*NT - core_id*NT;
     int tmask = (1 << rT) - 1;
     spawn_kernel_rem_cb(tmask);
   }


### PR DESCRIPTION
patch to fix the rT (thread reminder) distribution bug explained in issue #79.
The patch adds 9 assembly instructions to the runtime library. These can be optimized, e.g. using `vx_thread_lid()` against `vx_thread_gid()`, but we preferred keeping the existing coding patterns.

Some more explanation:
While benchmarking some specific kernels on Vortex we noticed errors in the execution. These were linked to the global kernel execution id each thread was executing. We understood mistakes happened when calling the `spawn_kernel_rem_stub()`.
Global (workgroup) kernel iteration was there computed as:
`int wg_id = p_wspawn_args->offset + vx_thread_gid()`
where the offset is computed in the `vx_kernel_spawn()` as 
`wspawn_args.offset = wgs_per_core0 - rT;`

Here you can see what is wrong: let's take a system with 1 cluster, 4 cores, 1 warp, and 4 threads.
Let's execute `vecadd` with 20 units and `local_work_size=1`
The rT (remaining/odd threads) to be executed will have the bold gid (*):
```
 **4**   3   2   1   0
 **9**   8   7   6   5
**14** 13 12 11 10
**19** 18 17 16 15
```
The offset will the same for every code as `5-1=4`
wg_id will be for different cores (only 1 thread active!) (**):
```
core0=4+0=4  with tid=0
core1=4+4=8 with tid=4
core2=4+8=12 with tid=8
core3=4+12=16 with tid=12
```
where tid is the global thread id that will execute the global kernel interaction id.
As you can see the expected gids (*) do not match the one evaluated by the old code (**)

Our patch fixes this issue:
1.  giving an offset that is dependent on the code_id
2. taking into account eventual full warp iterations (when warps>1) that only the last core executes
(try to make again the exercise above with `vecadd` with **47** or **31** elements)

